### PR TITLE
Fix field mapping issues in relationships

### DIFF
--- a/autoform.py
+++ b/autoform.py
@@ -148,8 +148,8 @@ class AutoForm:
 
             for a_table in foreign_tables:
                 pkeyName = relationretriever.retrieveTablePrimaryKeyName()
-                ref_foreign_col_num = relationretriever.retrieveForeignCol()
-                ref_native_col_num = relationretriever.retrieveNativeCol()
+                ref_foreign_col_num = relationretriever.retrieveForeignCol(uri)
+                ref_native_col_num = relationretriever.retrieveNativeCol(uri)
                 new_layer = self.addRefTables(uri, a_table[0], pkeyName, tableGroup)
 
                 if new_layer is not False:
@@ -162,7 +162,7 @@ class AutoForm:
         foreign_uri.setDataSource(uri.schema(), table, None, "", attr_name)
         new_layer = QgsVectorLayer(foreign_uri.uri(), table, "postgres")
 
-        if new_layer.isValid:
+        if new_layer.isValid():
             layer_exists = False
 
             for layers in QgsMapLayerRegistry.instance().mapLayers().values():

--- a/relationretriever.py
+++ b/relationretriever.py
@@ -38,11 +38,12 @@ class RelationRetriever:
         self.cur.execute(oid_query)
         layer_oid = self.cur.fetchone()
 
-        return layer_oid
+        return layer_oid[0]
 
-    def retrieveForeignCol(self):
+    def retrieveForeignCol(self, uri):
         """Retrieve the number of the field which is referenced in the foreign key relation."""
-        fkey_query = "SELECT confkey FROM pg_constraint WHERE confrelid = %s AND contype = 'f'" % self.layer
+        selected_oid = self.retrieveSelectedOid(uri)
+        fkey_query = "SELECT confkey FROM pg_constraint WHERE conrelid = '%s' AND confrelid = %s AND contype = 'f'" % (selected_oid, self.layer)
         self.cur.execute(fkey_query)
         fkey_column = self.cur.fetchall()
 
@@ -51,9 +52,10 @@ class RelationRetriever:
 
         return ref_foreign_col_num
 
-    def retrieveNativeCol(self):
+    def retrieveNativeCol(self, uri):
         """Retrieve the number of the field which makes a reference in the foreign key relation."""
-        nfield_query = "SELECT conkey FROM pg_constraint WHERE confrelid = %s AND contype = 'f'" % self.layer
+        selected_oid = self.retrieveSelectedOid(uri)
+        nfield_query = "SELECT conkey FROM pg_constraint WHERE conrelid = '%s' AND confrelid = %s AND contype = 'f'" % (selected_oid, self.layer)
         self.cur.execute(nfield_query)
         nfield_column = self.cur.fetchall()
 


### PR DESCRIPTION
Fix support for QGIS v2.14 (previously getting out-of-range errors due to wrong field indices) as well as field mapping errors for QGIS v2.18 (e.g., value relations were being assigned to fields not involved in relations).

Without adding `conrelid` in the WHERE clause, queries inside both `retrieveForeignCol()` and `retrieveNativeCol()` can give you several field indices. The plugin seems to be choosing the last one, which only by chance might be the correct one. 